### PR TITLE
Fixed command injection in geojson2kml

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,9 @@
-var exec = require('child_process').exec,
+var exec = require('child_process').execFile,
     path = require('path')
 
 module.exports = function(inPath, outPath, done){
-  var ogrCommand = 'ogr2ogr -f KML '+outPath+ ' '+inPath
-  exec(ogrCommand, function(err, stdout, stderr){
+  var ogrCommand = ['-f' , 'KML', outPath, inPath]
+  exec('ogr2ogr', ogrCommand, function(err, stdout, stderr){
     done(err)
   })
 }


### PR DESCRIPTION
### 📊 Metadata *

Command injection vulnerability 
#### Bounty URL:  https://www.huntr.dev/bounties/1-npm-geojson2kml/

### ⚙️ Description *

The `geojson2kml` module is vulnerable against RCE since the command is crafted using user inputs not validated and then executed, leading to arbitrary command injection. The argument options can be controlled by users without any sanitization. It was using `exec()` function which is vulnerable to **Command Injection** if it accepts user input and it goes through any sanitization or escaping.

### 💻 Technical Description *

The use of the `child_process` function `exec()` is highly discouraged if you accept user input and don't sanitize/escape them. I replaced it with `execFile()` which mitigates any possible Command Injections as it accepts input as arrays.

### 🐛 Proof of Concept (PoC) *

Install the package and run the below code, you'll need to have a PDF to test:
```javascript
// poc.js
var a =require("geojson2kml");
a("./","& calc.exe",function(){})
```
`calc.exe` will be popped.

### 🔥 Proof of Fix (PoF) *

After applying the fix, run the PoC again and no files will be created. Hence command injection is mitigated.

### 👍 User Acceptance Testing (UAT)

Only `execFile` is used, no breaking changes introduced.
